### PR TITLE
Use timeout setting when creating production database backup

### DIFF
--- a/src/PullProductionDataCommand.php
+++ b/src/PullProductionDataCommand.php
@@ -140,6 +140,7 @@ class PullProductionDataCommand extends Command
         );
 
         $process = new Process(['ssh', "{$this->user}@{$this->host}", "-p{$this->port}", $command]);
+        $process->setTimeout(config('pull-production-data.timeout'));
         $process->run();
 
         $this->info('Backup created!');


### PR DESCRIPTION
This PR updates the "Creating production database backup" step to use the timeout value specified in the config file. Without this, the `mysqldmp` command would timeout on our server when backing up from a large database.